### PR TITLE
Add user page information for keeping track of data updates

### DIFF
--- a/src/main/java/com/danielvm/destiny2bot/entity/UserPageInformation.java
+++ b/src/main/java/com/danielvm/destiny2bot/entity/UserPageInformation.java
@@ -1,0 +1,17 @@
+package com.danielvm.destiny2bot.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserPageInformation {
+
+  private Long userDiscordId;
+
+  private Integer numberOfPages;
+
+  private Integer lastPageCount;
+}

--- a/src/main/resources/db/migration/V2__Create_Pagination_Table.sql
+++ b/src/main/resources/db/migration/V2__Create_Pagination_Table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE user_page_information
+(
+    user_discord_id BIGINT PRIMARY KEY,
+    number_of_pages INTEGER,
+    last_page_count INTEGER,
+    CONSTRAINT discord_id_fk FOREIGN KEY (user_discord_id) REFERENCES bot_user (discord_id)
+);


### PR DESCRIPTION
This PR adds user page information to keep track of user data updates for their raid information. The reason why we do this is because the raid information API does not give any additional information of how many elements a user might have left nor how many pages of information the user has left.